### PR TITLE
List children in category list

### DIFF
--- a/partials/blog/categories.htm
+++ b/partials/blog/categories.htm
@@ -1,16 +1,10 @@
-{% set categories = blogCategories.categories %}
-{% set currentCategorySlug = blogCategories.currentCategorySlug %}
 
 <div class="list-group">
-    {% for category in categories %}
-        {% set postCount = category.post_count %}
-        <a
-            href="{{ category.url }}"
-            class="list-group-item {{ category.slug == currentCategorySlug ? 'active' }}"
-            >{{ category.name }}
-            {% if postCount %}
-                <span class="badge">{{ postCount }}</span>
-            {% endif %}
-        </a> 
+    {% for category in blogCategories.categories %}
+      {% partial "blog/category-item.htm" category=category %}
+
+      {% for child in category.children %}
+        {% partial "blog/category-item.htm" category=child %}
+      {% endfor %}
     {% endfor %}
 </div>

--- a/partials/blog/categories.htm
+++ b/partials/blog/categories.htm
@@ -1,10 +1,10 @@
 
 <div class="list-group">
     {% for category in blogCategories.categories %}
-      {% partial "blog/category-item.htm" category=category %}
+      {% partial "blog/category-item" category=category %}
 
       {% for child in category.children %}
-        {% partial "blog/category-item.htm" category=child %}
+        {% partial "blog/category-item" category=child %}
       {% endfor %}
     {% endfor %}
 </div>

--- a/partials/blog/category-item.htm
+++ b/partials/blog/category-item.htm
@@ -1,0 +1,9 @@
+{% set currentCategorySlug = blogCategories.currentCategorySlug %}
+<a
+    href="{{ category.url }}"
+    class="list-group-item {{ category.slug == currentCategorySlug ? 'active' }}"
+    >{{ category.name }}
+    {% if category.post_count > 0 %}
+        <span class="badge">{{ postCount }}</span>
+    {% endif %}
+</a>


### PR DESCRIPTION
October supports nested categories, but the category list only includes the ones in the root.

This patch loops through each category's children and adds them to the list