### PR TITLE
Split blog post partials

### DIFF
--- a/partials/blog/post.htm
+++ b/partials/blog/post.htm
@@ -1,0 +1,29 @@
+<div class="media">
+
+    <div class="media-left">
+        <a href="{{ post.url }}">
+            {% if post.featured_images.count > 0 %}
+                <img class="media-object" src="{{ post.featured_images.first.getThumb(100, 'auto') }}" />
+            {% else %}
+                <img class="media-object" src="http://placehold.it/100x100" />
+            {% endif %}
+        </a>
+    </div>
+
+    <div class="media-body">
+        <h4 class="media-heading">
+            <a href="{{ post.url }}">{{ post.title }}</a>
+        </h4>
+        <p class="info">
+            Posted
+            {% if post.categories.count %} in {% endif %}
+            {% for category in post.categories %}
+                <a href="{{ category.url }}">{{ category.name }}</a>{% if not loop.last %}, {% endif %}
+            {% endfor %}
+            on {{ post.published_at|date('M d, Y') }}
+        </p>
+
+        <p class="excerpt">{{ post.summary|raw }}</p>
+    </div>
+</div>
+

--- a/partials/blog/posts.htm
+++ b/partials/blog/posts.htm
@@ -2,34 +2,7 @@
 
 <div class="post-list">
     {% for post in posts %}
-        <div class="media">
-
-            <div class="media-left">
-                <a href="{{ post.url }}">
-                    {% if post.featured_images.count > 0 %}
-                        <img class="media-object" src="{{ post.featured_images.first.getThumb(100, 'auto') }}" />
-                    {% else %}
-                        <img class="media-object" src="http://placehold.it/100x100" />
-                    {% endif %}
-                </a>
-            </div>
-
-            <div class="media-body">
-                <h4 class="media-heading">
-                    <a href="{{ post.url }}">{{ post.title }}</a>
-                </h4>
-                <p class="info">
-                    Posted
-                    {% if post.categories.count %} in {% endif %}
-                    {% for category in post.categories %}
-                        <a href="{{ category.url }}">{{ category.name }}</a>{% if not loop.last %}, {% endif %}
-                    {% endfor %}
-                    on {{ post.published_at|date('M d, Y') }}
-                </p>
-
-                <p class="excerpt">{{ post.summary|raw }}</p>
-            </div>
-        </div>
+      {% partial "blog/post" post=post %}
     {% else %}
         <div class="no-data">
             <p>{{ noPostsMessage }}</p>


### PR DESCRIPTION
This PR splits the posts.htm file into posts.htm and post.htm, where post.html only shows a single post and posts.htm loops through the posts, including the post.htm partial.

It's just a minor patch.

The contents of post.htm is just exactly what posts.htm had.